### PR TITLE
Fix CI for forks

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -27,6 +27,7 @@ jobs:
           args: "--bibliography=thesis/latex/bibliography.bib --to=html --wrap=none --output=index.html thesis/latex/thesis.tex"
       - name: Deploy report
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.repository == 'janschill/cern-solid-code-investigation' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           exclude_assets: '.github,agreements,examples,meetings,notes,presentations,prototype,report,thesis/,.gitignore,.gitmodules,README.md,thesis.acn,thesis.aux,thesis.bbl,thesis.bcf,thesis.blg,thesis.fdb_latexmk,thesis.fls,thesis.glo,thesis.ist,thesis.log,thesis.out,thesis.run.xml,thesis.toc'


### PR DESCRIPTION
This step will fail if a fork is configured with limited default permissions. Unless someone specifically expects forks to use this portion of the workflow, it seems like the simplest fix is to only use it for the primary repository.